### PR TITLE
Use TrustedHostMiddleware for Auth Module

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,6 @@ from fastapi import FastAPI
 from routers import sports_router, sport_router, medals_router, medal_router, audient_router, apikeygen_router
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
-from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from decouple import config, Csv
 
 app = FastAPI()
@@ -14,16 +13,18 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+auth_origins = config("ALLOWED_AUTH_ORIGINS", cast=Csv())
 authentication = FastAPI()
 authentication.add_middleware(
     CORSMiddleware,
-    allow_origins=config("ALLOWED_AUTH_ORIGINS", cast=Csv()),
+    allow_origins=auth_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 authentication.add_middleware(
-    
+    TrustedHostMiddleware,
+    allowed_hosts=auth_origins
 )
 
 app.mount("/apigenkey", authentication)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
 from routers import sports_router, sport_router, medals_router, medal_router, audient_router, apikeygen_router
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.trustedhost import TrustedHostMiddleware
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from decouple import config, Csv
 
 app = FastAPI()
@@ -19,6 +21,9 @@ authentication.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+)
+authentication.add_middleware(
+    
 )
 
 app.mount("/apigenkey", authentication)


### PR DESCRIPTION
This PR proposes using TrustedHostMiddleware to auth module, with CORS you are limit on how the resource can be shared. Allowing hosts ensure that Host header is coming from the correct location, this further secures our authorization module.