### PR TITLE
Add implementation for GET /sports/ route; and fix routing of auth module

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ authentication.add_middleware(
     allowed_hosts=auth_origins
 )
 
-app.mount("/apigenkey", authentication)
+app.mount("/apikeygen", authentication)
 
 app.include_router(sports_router.router)
 app.include_router(sport_router.router)
@@ -36,7 +36,7 @@ app.include_router(medal_router.router)
 app.include_router(audient_router.router)
 
 # to be separated into another CORS configuration
-app.include_router(apikeygen_router.router)
+authentication.include_router(apikeygen_router.router)
 
 
 @app.get("/")

--- a/routers/apikeygen_router.py
+++ b/routers/apikeygen_router.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from .deps.auth_deps import AuthScope
 import random, string
 
-router = APIRouter(prefix="/apikeygen", tags=["keygen"])
+router = APIRouter(tags=["keygen"])
 
 
 class ScopeDict(BaseModel):

--- a/routers/sports_router.py
+++ b/routers/sports_router.py
@@ -1,12 +1,29 @@
 from fastapi import APIRouter
+from database_connection import sport_detail_collection
+
+router = APIRouter(prefix="/sports", tags=["sports"])
 
 
-router = APIRouter(
-    prefix="/sports",
-    tags=["sports"]
-)
-
-
-@router.get("/sports")
+@router.get("/")
 def get_all_sports_id():
-    return {"test": "all good"}
+
+    sport_pairs = sport_detail_collection.aggregate(
+        [
+            {
+                "$replaceRoot": {
+                    "newRoot": {
+                        "$arrayToObject": [
+                            [{"k": {"$toString": "$sport_id"}, "v": "$sport_name"}]
+                        ]
+                    }
+                }
+            }
+        ]
+    )
+
+    res = dict()
+    for entry in sport_pairs:
+        item = list(entry.items())[0]
+        res[item[0]] = item[1]
+
+    return res

--- a/sample.env
+++ b/sample.env
@@ -1,16 +1,16 @@
 # connection string for mongo database
 MONGO = mongodb://localhost:27017
 # allowed hosts
-ALLOWED_ORIGINS = ???
+ALLOWED_ORIGINS = 127.0.0.1,localhost
 # allowed auth hosts
-ALLOWED_AUTH_ORIGINS = ???
+ALLOWED_AUTH_ORIGINS = 127.0.0.1,localhost
 
 # database name
-DATABASE = ???
+DATABASE = Sota
 
 # collection names
-SPORT_DETAIL_COLLECTION = ???
-SUB_SPORT_COLLECTION = ???
-AUDIENT_COLLECTION = ???
-MEDAL_COLLECTION = ???
-KEYS_COLLECTION = ???
+SPORT_DETAIL_COLLECTION = SportDetail
+SUB_SPORT_COLLECTION = SubSportType
+AUDIENT_COLLECTION = Audient
+MEDAL_COLLECTION = Medal
+KEYS_COLLECTION = Keys


### PR DESCRIPTION
## Overview
This PR adds and modifies the system by:
* Added a working implementation for GET /sports/ route.
* Fixed the name for auth keygen route.
* Fixed the routing hierarchy for auth module.
* Added examples for environment variables configuration.

## Further Improvement
We should implement a cache system, so that pymongo wouldn't need to always aggregate data.