### PR TITLE
feat: Implement GET `/medal/c/c:country_code` endpoint with `sub_sports`

### DIFF
--- a/sota/routers/medal_router.py
+++ b/sota/routers/medal_router.py
@@ -7,7 +7,7 @@ router = APIRouter(prefix="/medal", tags=["medal"])
 @router.get("/c/{country_code}")
 def get_medal_by_country(country_code: str):
     pipeline = [
-        {"$match": {"country_code": f"{country_code}"}},
+        {"$match": {"country_code": country_code}},
         {"$unwind": {"path": "$sports"}},
         {
             "$lookup": {


### PR DESCRIPTION
- Add working implementation for GET /medal/c/c:country_code endpoint
- I actually tested it on the mock data, so it should be fine. **Trust me bro!**
<img width="418" alt="Screenshot 2566-10-28 at 13 13 06" src="https://github.com/SPaM-Skill-Issue/sota-backend/assets/92836314/0eecf31f-f200-4f34-b1a7-62d55e76681f">

### OUTPUT
```
{
	"country_name": "United States of America",
	"gold": 40,
	"silver": 20,
	"bronze": 10,
	"individual_sports": [
		{
			"sport_id": 1,
			"sport_name": "Archery",
			"gold": 30,
			"silver": 20,
			"bronze": 10,
			"sub_sports": [
				{
					"sub_id": 1,
					"sub_name": "Individual Men's",
					"gold": 10,
					"silver": 10,
					"bronze": 0
				},
				{
					"sub_id": 2,
					"sub_name": "Individual Women's",
					"gold": 20,
					"silver": 10,
					"bronze": 10
				}
			]
		},
		{
			"sport_id": 2,
			"sport_name": "Artistic Gymnastics",
			"gold": 10,
			"silver": 0,
			"bronze": 0,
			"sub_sports": [
				{
					"sub_id": 3,
					"sub_name": "Individual All-Around Men's",
					"gold": 10,
					"silver": 0,
					"bronze": 0
				}
			]
		}
	],
	"country": "US"
}
```