### PR TITLE
Bugfix: Incorrect Matching within sports Array in MongoDB Query

### DIFF
--- a/sota/routers/medals_router.py
+++ b/sota/routers/medals_router.py
@@ -100,12 +100,16 @@ async def update_medal(data: RequestUpdateMedal):
             "bronze": request_participant.medal.bronze,
         }
 
-        # Attempt to update existing document or create a new one
+        # Attempt to update existing document or create a new one using $elemMatch
         updated = medal_collection.update_one(
             {
                 "country_code": country_code,
-                "sports.sport_id": data.sport_id,
-                "sports.type_id": data.sport_type_id,
+                "sports": {
+                    "$elemMatch": {
+                        "sport_id": data.sport_id,
+                        "type_id": data.sport_type_id
+                    }
+                }
             },
             {
                 "$set": {

--- a/sota/routers/medals_router.py
+++ b/sota/routers/medals_router.py
@@ -107,9 +107,9 @@ async def update_medal(data: RequestUpdateMedal):
                 "sports": {
                     "$elemMatch": {
                         "sport_id": data.sport_id,
-                        "type_id": data.sport_type_id
+                        "type_id": data.sport_type_id,
                     }
-                }
+                },
             },
             {
                 "$set": {


### PR DESCRIPTION
## Bugfix: Incorrect Matching within sports Array in MongoDB Query
### Problem:
The current MongoDB filter:
```
  {
    "country_code": country_code,
    "sports.sport_id": data.sport_id,
    "sports.type_id": data.sport_type_id,
  }
```
Here mongo attempts to match both `sports.sport_id` and `sports.type_id` within the array of sports. However, MongoDB processes each condition separately, leading to unintended matches. Specifically, MongoDB can match a sport_id from one element and a type_id from another within the sports array, yielding inaccurate results.

## Solution:
To resolve this issue, we've employed the `$elemMatch` operator, ensuring both the `sport_id` and `type_id` are simultaneously matched within the same sports array element.
### Updated FIlter:
```
{
    "country_code": country_code,
    "sports": {
        "$elemMatch": {
            "sport_id": data.sport_id,
            "type_id": data.sport_type_id
        }
    }
}
```

## Owner:
<img src="https://media.tenor.com/uFxiuS-FzzEAAAAd/monkey-macaco.gif" width="300" height="300"/>

