### PR TITLE
Quick fix: Add authentication dependencies to POST routes to secure our application

### DIFF
--- a/sota/routers/audient_router.py
+++ b/sota/routers/audient_router.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from pymongo import DESCENDING
 from pydantic import BaseModel, validator
 from typing import List
 from ..database_connection import audient_collection
+from .deps.auth_deps import check_auth_key, CheckPermissionsOfKey, AuthScope
 
 
 router = APIRouter(
@@ -40,7 +41,12 @@ def get_audient():
     audient_all = [convert_data(audient) for audient in audient_collection.find()]
     return audient_all
 
-@router.post("/update_audient_info")
+@router.post("/update_audient_info", dependencies=[
+    Depends(check_auth_key),
+    Depends(CheckPermissionsOfKey([
+        AuthScope.PUBLISH_AUDIENCE
+    ]))
+])
 async def update_audient_info(data: RequestListOfAudientData):
     audient_data = data.dict()
     for item in audient_data["audience"]:

--- a/sota/routers/medals_router.py
+++ b/sota/routers/medals_router.py
@@ -1,8 +1,9 @@
 from pydantic import BaseModel, model_validator, Field
 import pycountry
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from ..database_connection import medal_collection, sub_sport_collection
+from .deps.auth_deps import check_auth_key, CheckPermissionsOfKey, AuthScope
 
 
 router = APIRouter(prefix="/medals", tags=["medals"])
@@ -88,7 +89,12 @@ def get_participating_countries(sport_id: int, sport_type_id: int) -> list:
     return detail["participating_countries"] if detail else []
 
 
-@router.post("/update_medal")
+@router.post("/update_medal", dependencies=[
+    Depends(check_auth_key),
+    Depends(CheckPermissionsOfKey([
+        AuthScope.PUBLISH_MEDAL
+    ]))
+])
 async def update_medal(data: RequestUpdateMedal):
     for request_participant in data.participants:
         country_code = request_participant.country


### PR DESCRIPTION
The current state of POST routes can be used by anyone (with or without token), this pull request fixes the situation where we add dependencies to each decorator with respective permissions.

After this merge, we'll bring the production deployment back online.