### PR TITLE
Update HTTP status code responses for validation errors

### DIFF
--- a/sota/routers/audient_router.py
+++ b/sota/routers/audient_router.py
@@ -1,15 +1,19 @@
-from fastapi import APIRouter, Depends
-from pymongo import DESCENDING
-from pydantic import BaseModel, validator
+# Standard library imports
 from typing import List
-from ..database_connection import audient_collection
+
+# Third-party imports
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, validator
+import pycountry
+
+# Local application imports
+from ..database_connection import audient_collection, sport_detail_collection
 from .deps.auth_deps import check_auth_key, CheckPermissionsOfKey, AuthScope
 
 
-router = APIRouter(
-    prefix="/audient",
-    tags=["audient"]
-)
+country_codes = [country.alpha_2 for country in pycountry.countries]
+router = APIRouter(prefix="/audient", tags=["audient"])
+
 
 class RequestAudientData(BaseModel):
     id: str
@@ -22,37 +26,52 @@ class RequestAudientData(BaseModel):
     def validate_gender(cls, value):
         allowed_values = {"M", "F", "N"}
         if value not in allowed_values:
-            raise ValueError("Invalid value for gender. It must be 'M', 'F', or 'N'.")
+            raise ValueError(
+                f"Invalid value for gender {value}. It must be 'M', 'F', or 'N'."
+            )
         return value
+
+    @validator("country_code")
+    def validate_country_code(cls, value):
+        if value not in country_codes:
+            raise ValueError(f"Country {value} doesn't exist")
+        return value
+
+    @validator("sport_id", each_item=True)
+    def validate_sport_id(cls, value):
+        if not sport_detail_collection.find_one({"sport_id": value}):
+            raise ValueError(f"The sport_id {value} doesn't exist")
+        return value
+
 
 class RequestListOfAudientData(BaseModel):
     audience: List[RequestAudientData]
 
+
 def convert_data(data):
-    return{
+    return {
         "country_code": data["country_code"],
         "sport_id": data["sport_id"],
         "gender": data["gender"],
-        "age": data["age"]
+        "age": data["age"],
     }
+
 
 @router.get("/")
 def get_audient():
     audient_all = [convert_data(audient) for audient in audient_collection.find()]
     return audient_all
 
-@router.post("/update_audient_info", dependencies=[
-    Depends(check_auth_key),
-    Depends(CheckPermissionsOfKey([
-        AuthScope.PUBLISH_AUDIENCE
-    ]))
-])
+
+@router.post(
+    "/update_audient_info",
+    dependencies=[
+        Depends(check_auth_key),
+        Depends(CheckPermissionsOfKey([AuthScope.PUBLISH_AUDIENCE])),
+    ],
+)
 async def update_audient_info(data: RequestListOfAudientData):
-    audient_data = data.dict()
+    audient_data = data.model_dump()
     for item in audient_data["audience"]:
-        audient_collection.update_one(
-            {"_id": item["id"]},
-            {"$set": item},
-            upsert=True
-        )
+        audient_collection.update_one({"_id": item["id"]}, {"$set": item}, upsert=True)
     return {"Success": audient_data}

--- a/sota/routers/audient_router.py
+++ b/sota/routers/audient_router.py
@@ -3,7 +3,7 @@ from typing import List
 
 # Third-party imports
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, Field, validator
 import pycountry
 
 # Local application imports
@@ -20,7 +20,7 @@ class RequestAudientData(BaseModel):
     country_code: str
     sport_id: List[int]
     gender: str
-    age: int
+    age: int = Field(ge=0)
 
     @validator("gender")
     def validate_gender(cls, value):


### PR DESCRIPTION
## Overview
This pull request updates the HTTP status code returned for validation errors from `422 Unprocessable Entity` to `400 Bad Request`. The changes affect two endpoints:

- `/medals/update_medal`
- `/audient/update_audient_info`

## Changes
- The `update_medal` endpoint now returns a `400 Bad Request` status code when there are missing fields or invalid field values.
- Similarly, the `update_audient_info` endpoint has been updated to return a `400 Bad Request` status code under the same circumstances.

## Rationale
The HTTP 422 status code is meant for situations where the server understands the content type of the request entity, and the syntax of the request entity is correct, but it was unable to process the contained instructions. However, for general validation errors such as missing fields or invalid field values, a `400 Bad Request` is more appropriate. This change aligns our API with the standard usage of HTTP status codes.

Please review the changes and provide your feedback.

Regards,
Jack Hanma